### PR TITLE
Fix: update np.loadtxt with old default encoding argument

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+0.18.4
+ - fix: update np.loadtxt with old default encoding argument (#29)
 0.18.3
  - ci: fix readthedocs.yml
 0.18.2

--- a/afmformats/formats/fmt_ntmdt_txt.py
+++ b/afmformats/formats/fmt_ntmdt_txt.py
@@ -31,7 +31,8 @@ def detect_txt(path):
     """File should be plain text"""
     valid = False
     try:
-        rawdata = np.loadtxt(path, converters=converters, max_rows=10)
+        rawdata = np.loadtxt(path, converters=converters, max_rows=10,
+                             encoding="bytes")
     except (ValueError, IndexError):
         pass
     else:
@@ -85,7 +86,7 @@ def load_txt(path, callback=None, meta_override=None):
             mis_metadata,
             f"Please specify {' and '.join(mis_metadata)}!")
 
-    rawdata = np.loadtxt(path, converters=converters)
+    rawdata = np.loadtxt(path, converters=converters, encoding="bytes")
 
     if rawdata.shape[1] != 3:
         raise errors.InvalidFileFormatError(

--- a/afmformats/formats/fmt_workshop/ws_single.py
+++ b/afmformats/formats/fmt_workshop/ws_single.py
@@ -136,7 +136,8 @@ def load_csv(path, callback=None, meta_override=None, mode="single"):
             "Unknown file format: {}".format(path))
 
     # load data
-    rawdata = np.loadtxt(path, skiprows=header_index+1, delimiter=",")
+    rawdata = np.loadtxt(path, skiprows=header_index+1, delimiter=",",
+                         encoding="bytes")
     segsize = rawdata.shape[0]
     data = {"height (measured)": np.zeros(2*segsize, dtype=float)*np.nan,
             "force": np.zeros(2*segsize, dtype=float)*np.nan,


### PR DESCRIPTION
As described in #29, Numpy changed the default value for `np.loadtxt`'s encoding argument. This PR sets it to `encoding="bytes"`