### PR TITLE
Load `.jpk-qi-data` metadata using `jpk-reader-rs` package

### DIFF
--- a/afmformats/formats/fmt_jpk/__init__.py
+++ b/afmformats/formats/fmt_jpk/__init__.py
@@ -1,19 +1,18 @@
 import numpy as np
+import jpk_reader_rs as jpk_rs
 
 from ...errors import MissingMetaDataError
 from ...lazy_loader import LazyData
 from ...meta import LazyMetaValue
 
-from .jpk_reader import JPKReader
+from .jpk_reader import JPKReader, JPKQIMapReader
 
 
 __all__ = ["load_jpk"]
 
 
 def detect(path, return_modality=False):
-    """Check whether a file is a valid JPK data file
-
-    """
+    """Check whether a file is a valid JPK data file"""
     # The suffix is not checked, because that is done in
     # the wrapper class formats.AFMFormatRecipe.
     jpkr = JPKReader(path)
@@ -60,6 +59,89 @@ def load_jpk(path, callback=None, meta_override=None):
     # iterate over all datasets and add them
     for index in range(len(jpkr)):
         lazy_data = LazyData()
+        for column in [
+            "force",
+            "height (measured)",
+            "height (piezo)",
+            "segment",
+            "time",
+        ]:
+            lazy_data.set_lazy_loader(
+                column=column,
+                func=jpkr.get_data,
+                kwargs={"column": column, "index": index},
+            )
+        metadata = jpkr.get_metadata(index=index)
+        metadata["z range"] = LazyMetaValue(
+            lambda data: np.ptp(data["height (piezo)"]), lazy_data
+        )
+        dataset.append(
+            {
+                "data": lazy_data,
+                "metadata": metadata,
+            }
+        )
+        if callback:
+            callback((1 + index) / len(jpkr))
+    return dataset
+
+
+def load_jpk_qi_data(path, callback=None, meta_override=None):
+    """Loads JPK QMap data
+
+    These files are zip files containing java property files and
+    integer-encoded binary data. The property files include recipes
+    on how to convert the raw integer data to SI units.
+
+    Parameters
+    ----------
+    path: str or pathlib.Path
+        path to JPK data file
+    callback: callable
+        function for progress tracking; must accept a float in
+        [0, 1] as an argument.
+    meta_override: dict
+        if specified, contains key-value pairs of metadata that
+        are used when loading the files
+        (see :data:`afmformats.meta.META_FIELDS`)
+    """
+    # if meta_override is None:
+    #     meta_override = {}
+
+    # jpkr = JPKReader(path)
+    # jpkr.set_metadata(meta_override)
+
+    # dataset = []
+    # # iterate over all datasets and add them
+    # for index in range(len(jpkr)):
+    #     lazy_data = LazyData()
+    #     for column in ["force", "height (measured)", "height (piezo)",
+    #                    "segment", "time"]:
+    #         lazy_data.set_lazy_loader(column=column,
+    #                                   func=jpkr.get_data,
+    #                                   kwargs={"column": column,
+    #                                           "index": index})
+    #     metadata = jpkr.get_metadata(index=index)
+    #     metadata["z range"] = LazyMetaValue(
+    #         lambda data: np.ptp(data["height (piezo)"]),
+    #         lazy_data)
+    #     dataset.append({"data": lazy_data,
+    #                     "metadata": metadata,
+    #                     })
+    #     if callback:
+    #         callback((1+index) / len(jpkr))
+    # return dataset
+
+    if meta_override is None:
+        meta_override = {}
+
+    jpkr = JPKQIMapReader(path)
+    jpkr.set_metadata(meta_override)
+
+    dataset = []
+    # iterate over all datasets and add them
+    for index in range(len(jpkr)):
+        lazy_data = LazyData()
         for column in ["force", "height (measured)", "height (piezo)",
                        "segment", "time"]:
             lazy_data.set_lazy_loader(column=column,
@@ -99,7 +181,7 @@ recipe_jpk_force_map = {
 recipe_jpk_force_qi_data = {
     "descr": "binary QMap data",
     "detect": detect,
-    "loader": load_jpk,
+    "loader": load_jpk_qi_data,
     "maker": "JPK Instruments",
     "modalities": ["creep-compliance", "force-distance", "stress-relaxation"],
     "suffix": ".jpk-qi-data",

--- a/afmformats/formats/fmt_jpk/__init__.py
+++ b/afmformats/formats/fmt_jpk/__init__.py
@@ -105,33 +105,6 @@ def load_jpk_qi_data(path, callback=None, meta_override=None):
         are used when loading the files
         (see :data:`afmformats.meta.META_FIELDS`)
     """
-    # if meta_override is None:
-    #     meta_override = {}
-
-    # jpkr = JPKReader(path)
-    # jpkr.set_metadata(meta_override)
-
-    # dataset = []
-    # # iterate over all datasets and add them
-    # for index in range(len(jpkr)):
-    #     lazy_data = LazyData()
-    #     for column in ["force", "height (measured)", "height (piezo)",
-    #                    "segment", "time"]:
-    #         lazy_data.set_lazy_loader(column=column,
-    #                                   func=jpkr.get_data,
-    #                                   kwargs={"column": column,
-    #                                           "index": index})
-    #     metadata = jpkr.get_metadata(index=index)
-    #     metadata["z range"] = LazyMetaValue(
-    #         lambda data: np.ptp(data["height (piezo)"]),
-    #         lazy_data)
-    #     dataset.append({"data": lazy_data,
-    #                     "metadata": metadata,
-    #                     })
-    #     if callback:
-    #         callback((1+index) / len(jpkr))
-    # return dataset
-
     if meta_override is None:
         meta_override = {}
 

--- a/afmformats/meta.py
+++ b/afmformats/meta.py
@@ -404,10 +404,12 @@ def parse_time(value):
     else:
         ss0 = ss
         ss1 = ""
-    if hh.endswith("\\"):
-        hh = hh[:-1]
-    if mm.endswith("\\"):
-        mm = mm[:-1]
+
+    # strip escape characters.
+    # See https://github.com/AFM-analysis/afmformats/issues/43
+    hh = hh.strip("\\")
+    mm = mm.strip("\\")
+    
     newvalue = ":".join(["{:02d}".format(int(hh)),
                          "{:02d}".format(int(mm)),
                          "{:02d}".format(int(ss0)) + ss1

--- a/afmformats/meta.py
+++ b/afmformats/meta.py
@@ -404,6 +404,10 @@ def parse_time(value):
     else:
         ss0 = ss
         ss1 = ""
+    if hh.endswith("\\"):
+        hh = hh[:-1]
+    if mm.endswith("\\"):
+        mm = mm[:-1]
     newvalue = ":".join(["{:02d}".format(int(hh)),
                          "{:02d}".format(int(mm)),
                          "{:02d}".format(int(ss0)) + ss1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,8 @@
 [build-system]
 requires = [
     # for version management
-    "setuptools>=45", "setuptools_scm[toml]>=6.2"
+    "setuptools>=45",
+    "setuptools_scm[toml]>=6.2",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -9,30 +10,31 @@ build-backend = "setuptools.build_meta"
 name = "afmformats"
 description = "reading common AFM file formats"
 authors = [
-    {name="Paul Müller", email="dev@craban.de"},
-    {name="Shada Abuhattum"},
-    {name="Eoghan O'Connell", email="eoclives@hotmail.com"},
+    { name = "Paul Müller", email = "dev@craban.de" },
+    { name = "Shada Abuhattum" },
+    { name = "Eoghan O'Connell", email = "eoclives@hotmail.com" },
 ]
 dynamic = ["version"]
 readme = "README.rst"
 license = "MIT"
-dependencies=[
+dependencies = [
     "h5py",
     "igor2>=0.5.0",  # Asylum Research .ibw file format
-    "jprops",  # JPK file format
+    "jprops",        # JPK file format
+    "jpk-reader-rs", # JPK QI data (`.jpk-qi-data`)
     "numpy>=1.14.0",
 ]
-requires-python=">=3.6, <4"
-keywords=[
+requires-python = ">=3.6, <4"
+keywords = [
     "atomic force microscopy",
     "mechanical phenotyping",
-    "tissue analysis"
+    "tissue analysis",
 ]
-classifiers=[
+classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Topic :: Scientific/Engineering :: Visualization",
-    "Intended Audience :: Science/Research"
+    "Intended Audience :: Science/Research",
 ]
 
 [project.urls]


### PR DESCRIPTION
Speeds up loading `.jpk-qi-data` files by using the [`jpk-reader-rs` package](https://pypi.org/project/jpk-reader-rs/) to load metadata.

Addresses #41, reducing load times of standard files by ~10x. For the test file it reduced the load time from more than 120 minutes to about 15. 

I [kept as much of the original `JPKReader` as possible](https://github.com/bicarlsen/afmformats/blob/00a43cdecd549ad8b78d80a3e88ecc45d3f66fb4/afmformats/formats/fmt_jpk/jpk_reader.py#L487) for this first pass. There is still quite some performance to be gained though, as the same test file loads in 20 seconds from [the Rust crate](https://github.com/bicarlsen/jpk_reader).

While probably not yet ready to be merged, I'm hoping can use it so we can address any issues that arise and continue to imporve upon performance.